### PR TITLE
Add option to hide ReadingTime, simplify duplicate code

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Hugo-Octopress is a port of the classic [Octopress][octopress-link] theme to [Hu
 ![screenshot](/images/screenshot2.png)
 
 ## <a name="config"></a>Configuration
-This section is about parameters in the [configuration file](https://gohugo.io/overview/configuration/) and how they can be used to customize the output. A working config file `sample-config.toml`is provided and parameters are explained below:
+This section is about parameters in the [configuration file](https://gohugo.io/overview/configuration/) and how they can be used to customize the output. A working config file `sample-config.toml` is provided and parameters are explained below:
 
 ``` python
 baseurl = "http://example.com/"
@@ -118,6 +118,8 @@ post = "/blog/:year-:month-:day-:title/"
   notfound_text = """Please either go back or use the navigation/sidebar menus.
   """
 
+  # Set to true to hide ReadingTime on posts
+  disableReadingTime = false
 ```
 
 ## <a name="highlight"></a>Code highlight

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -6,20 +6,8 @@
     {{ $paginator := .Paginate (where .Data.Pages "Type" "post") }}
     {{ range $paginator.Pages }}
     <article>
-      <header>
-        <h1 class="entry-title">
-          <a href="{{ .Permalink }}">{{ .Title }}</a>
-        </h1>
-        <p class="meta">{{ .Date.Format "Jan 2, 2006" }} - {{ .ReadingTime }} minute read - {{ if .Site.Params.disqusShortname }} <a href="{{ .Permalink }}#disqus_thread">Comments</a>{{ end }}
 
-        {{ if isset .Params "categories" }}
-        <!-- <br/> this will make the categories go to the second line and mess with the title -->
-        <!-- in order to make category URLs work, we need to urlize them and then convert them to lowercase
-             e.g. .NET Remoting -urlize-> .NET-Remoting -lowercase-> .net-remoting -->
-        {{ range .Params.categories }}<a class="label" href="{{ "/categories/" | absURL }}{{ . | urlize | lower }}/">{{ . }}</a>{{ end }}
-        {{ end }}</p>
-
-      </header>
+        {{ partial "post_header.html" . }}
 
         {{ if eq .Site.Params.truncate false }}
         {{ .Content }}

--- a/layouts/partials/post_header.html
+++ b/layouts/partials/post_header.html
@@ -1,0 +1,18 @@
+<!-- This file contains the header/title for each post -->
+
+<header>
+    <h1 class="entry-title">
+        {{ if .IsHome }} <a href="{{ .Permalink }}">{{ .Title }}</a> {{ else }} {{ .Title }} {{ end }}
+    </h1>
+    <p class="meta">{{ .Date.Format "Jan 2, 2006" }}
+        - {{ .ReadingTime }} minute read
+        {{ if .Site.Params.disqusShortname }} - <a href="{{ .Permalink }}#disqus_thread">Comments</a>{{ end }}
+
+        {{ if isset .Params "categories" }}
+        <!-- <br/> this will make the categories go to the second line and mess with the title -->
+        <!-- in order to make category URLs work, we need to urlize them and then convert them to lowercase
+             e.g. .NET Remoting -urlize-> .NET-Remoting -lowercase-> .net-remoting -->
+            - {{ range .Params.categories }}<a class="label" href="{{ "/categories/" | absURL }}{{ . | urlize | lower }}/">{{ . }}</a>{{ end }}
+        {{ end }}
+    </p>
+</header>

--- a/layouts/partials/post_header.html
+++ b/layouts/partials/post_header.html
@@ -5,7 +5,7 @@
         {{ if .IsHome }} <a href="{{ .Permalink }}">{{ .Title }}</a> {{ else }} {{ .Title }} {{ end }}
     </h1>
     <p class="meta">{{ .Date.Format "Jan 2, 2006" }}
-        - {{ .ReadingTime }} minute read
+        {{ if not .Site.Params.disableReadingTime }} - {{ .ReadingTime }} minute read {{ end }}
         {{ if .Site.Params.disqusShortname }} - <a href="{{ .Permalink }}#disqus_thread">Comments</a>{{ end }}
 
         {{ if isset .Params "categories" }}

--- a/layouts/post/single.html
+++ b/layouts/post/single.html
@@ -4,19 +4,9 @@
   <div id="content">
     <div>
       <article class="hentry" role="article">
-        <header>
-          <h1 class="entry-title">
-            {{ .Title }} <!-- we don't need page title to be a link on the actual page -->
-          </h1>
-          <p class="meta">{{ .Date.Format "Jan 2, 2006" }} - {{ .ReadingTime }} minute read - {{ if .Site.Params.disqusShortname }} <a href="{{ .Permalink }}#disqus_thread">Comments</a>{{ end }}
 
-          <!-- if you want anything in the header between Disqus comments and categories add them here -->
+        {{ partial "post_header.html" . }}
 
-          {{ if isset .Params "categories" }}
-          <!-- <br/> this will make the categories go to the second line and mess with the title -->
-          {{ range .Params.categories }}<a class="label" href="{{ "/categories/" | absURL }}{{ . | urlize | lower }}">{{ . }}</a>{{ end }}
-          {{ end }}</p>
-        </header>
         <div class="entry-content">
           <!-- insert table of contents if it is set either in the config file or in the frontmatter - frontmatter has priority -->
           {{ $.Scratch.Set "pagetoc" .TableOfContents }}

--- a/sample-config.toml
+++ b/sample-config.toml
@@ -136,6 +136,9 @@ post = "/blog/:year-:month-:day-:title/" # change the post URL to look like the 
 	notfound_text = """Please either go back or use the navigation/sidebar menus.
 	"""
 
+        # Set to true to hide ReadingTime on posts
+        disableReadingTime = false
+
 # blackfriday is Hugo's markdown engine. Options are at: https://gohugo.io/overview/configuration/ (scroll down to "Configure Blackfriday rendering")
 [blackfriday]
 	hrefTargetBlank = true # open the external links in a new window


### PR DESCRIPTION
Hello, thank you for porting this theme to Hugo!

This patch set:
* Moves duplicate code into a partial template. I'm not familiar with Go
  templating, so I used [Scratch](https://gohugo.io/extras/scratch), there
  might be a better way to do this.
* Formats the code a bit to be more readable.
* Adds an option to hide the ReadingTime label on posts.
* As a side effect, removes an orphan `-` character when disqus is disabled
  and a post has no categories.
