### PR TITLE
Various small fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,10 @@ post = "/blog/:year-:month-:day-:title/"
   # switch to true to enable RSS icon link in the navigation menu
   rss = true  
 
+  # set to true to use a text label for RSS instead of an icon
+  # this is overwritten by the `rss` setting
+  textrss = false
+
   # Website's default description used in meta tags
   defaultDescription = ""
 

--- a/README.md
+++ b/README.md
@@ -120,6 +120,9 @@ post = "/blog/:year-:month-:day-:title/"
 
   # Set to true to hide ReadingTime on posts
   disableReadingTime = false
+
+  # Set to true to disable downloading of remote Google fonts
+  disableGoogleFonts = false
 ```
 
 ## <a name="highlight"></a>Code highlight

--- a/layouts/indexes/tag.html
+++ b/layouts/indexes/tag.html
@@ -27,13 +27,13 @@
             </time>
             <footer>
               <span class="categories"> <!-- show categories and tags -->
-                posted in:
                 {{ if isset .Params "categories" }}
+                posted in:
                 {{ range .Params.categories }} <a class="category" href="{{ "/categories/" | absURL }}{{ . | urlize | lower }}">{{ . }}</a>{{ end }}
-                {{ end }}
               </br>
-                tags:
+                {{ end }}
                 {{ if isset .Params "tags" }}
+                tags:
                 {{ range .Params.tags }} <a class="category" href="{{ "/tags/" | absURL }}{{ . | urlize | lower }}">{{ . }}</a>{{ end }}
                 {{ end }}
               </span>

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -9,9 +9,11 @@
   <meta name="MobileOptimized" content="320">
   <meta name="viewport" content="width=device-width,minimum-scale=1,maximum-scale=1">
 
+  {{ if not .Site.Params.disableGoogleFonts }}
   <!--Fonts from Google"s Web font directory at http://google.com/webfonts added from Octo-->
   <link href="//fonts.googleapis.com/css?family=PT+Serif:regular,italic,bold,bolditalic" rel="stylesheet" type="text/css">
   <link href="//fonts.googleapis.com/css?family=PT+Sans:regular,italic,bold,bolditalic" rel="stylesheet" type="text/css">
+  {{ end }}
 
   <!-- goes into the title bar -->
   <title>{{ .Title }}</title>

--- a/layouts/partials/navigation.html
+++ b/layouts/partials/navigation.html
@@ -13,10 +13,13 @@
 
 <!-- http://fontawesome.io icon fa-lg adapts it to size (at least it is supposed to) -->
 <ul class="subscription">
-  {{ if .Site.Params.rss }}<a href="{{ "/index.xml" | absURL }}" target="_blank" type="application/rss+xml" title="RSS"><i class="fa fa-rss-square fa-lg"></i></a>{{ end }}
-
-  <!-- If you prefer RSS text (like Octopress) replace the line above with next comment -->
-  <!-- <li><a href="/index.xml" rel="subscribe-rss" title="subscribe via RSS">RSS</a></li> -->
+  {{ if or .Site.Params.rss .Site.Params.textrss }}
+    {{ if .Site.Params.rss }}
+        <a href="{{ "/index.xml" | absURL }}" target="_blank" type="application/rss+xml" title="RSS"><i class="fa fa-rss-square fa-lg"></i></a>
+    {{ else }}
+        <li><a href="/index.xml" rel="subscribe-rss" title="subscribe via RSS">RSS</a></li>
+    {{ end }}
+  {{ end }}
 
 </ul>
 

--- a/layouts/partials/post_footer.html
+++ b/layouts/partials/post_footer.html
@@ -5,12 +5,12 @@
     <span class="byline author vcard">Posted by <span class="fn">{{ with .Site.Params.author }}{{ . }}{{ end }}</span></span>
     <!-- can't put the .Date.Format inside the datetime attribute because of double quotes, so it's outside -->
     <time>{{ .Date.Format "Jan 2, 2006" }}</time>
-    <span class="categories">
-      Tags:
-        {{ if isset .Params "tags" }}
+    {{ if isset .Params "tags" }}
+      <span class="categories">
+        Tags:
         <!-- need to convert the tags to lower for the URLs to work -->
           {{ range .Params.tags }}<a class="category" href="{{ "/tags/" | absURL }}{{ . | urlize | lower }}">{{ . }}</a>  {{ end }}
-        {{ end }}
+    {{ end }}
     </span>
   </p>
 

--- a/sample-config.toml
+++ b/sample-config.toml
@@ -121,6 +121,10 @@ post = "/blog/:year-:month-:day-:title/" # change the post URL to look like the 
 
 	rss = true  # switch to true to enable RSS icon link
 
+        # set to true to use a text label for RSS instead of an icon
+        # this is overwritten by the `rss` setting
+        textrss = false
+
 	defaultDescription = ""
 
 	# populate this with your own keywords

--- a/sample-config.toml
+++ b/sample-config.toml
@@ -139,6 +139,9 @@ post = "/blog/:year-:month-:day-:title/" # change the post URL to look like the 
         # Set to true to hide ReadingTime on posts
         disableReadingTime = false
 
+        # Set to true to disable downloading of remote Google fonts
+        disableGoogleFonts = false
+
 # blackfriday is Hugo's markdown engine. Options are at: https://gohugo.io/overview/configuration/ (scroll down to "Configure Blackfriday rendering")
 [blackfriday]
 	hrefTargetBlank = true # open the external links in a new window


### PR DESCRIPTION
Hello,

this patchset fixes some minor cosmetic bugs and introduces two new settings.

* Hide categories and/or tag labels when a post doesn't have a category/tag.
* Add a new setting called `textrss` to use a text label for RSS instead of the
  font awesome icon. The code was already there, I just turned it into a
  setting. The way I've implemented this, backwards compatibility is kept I
  think.
* Add a setting called `disableGoogleFonts` to disable downloading of fonts
  from Google. I'm not sure many people will find this useful, but I prefer
  that my sites don't call on external services/domains/endpoints.

Any comments/ideas are welcome, feel free to cherry-pick any commits you like
and discard anything you find not needed (e.g., the Google fonts one).
