### PR TITLE
Fix searchEngineURL in nav

### DIFF
--- a/layouts/partials/navigation.html
+++ b/layouts/partials/navigation.html
@@ -23,8 +23,8 @@
 
 </ul>
 
-{{ if isset .Site.Params "searchEngineURL" }}
-<form action="{{ .Site.Params.searchEngineURL }}" method="get" target="_blank">
+{{ with .Site.Params.searchEngineURL }}
+<form action="{{ . }}" method="get" target="_blank">
   <fieldset role="search">
   	<input class="search" type="text" name="q" results="0" placeholder="Search"/>
     <input type="hidden" name="q" value="site:{{ "/" | absURL }}" />


### PR DESCRIPTION
Apparently, .Site.Params stores everything in lower case
so isset of a mixed case string will never find anything. Switch
to using with as recommended by
https://discuss.gohugo.io/t/config-params-should-be-all-lowercase-or-not/5051/2