### PR TITLE
Fix disqus code. Fixes #32.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,11 @@ languageCode = "en-us"
 title = "Site title"
 theme = "hugo-octopress"
 
+# Disqus shortcode
+# Disable comments for any individual post by adding "comments: false" in its frontmatter
+disqusShortname = "Your disqus shortname"
+
+
 # Number of blog posts in each pagination page
 paginate = 6
 
@@ -70,10 +75,6 @@ post = "/blog/:year-:month-:day-:title/"
 
 	# Google analytics code - remove if you do not have/want Google Analytics - needs JavaScript
 	googleAnalytics = "UA-XXXXX-X"
-
-	# Disqus shortcode
-	# Disable comments for any individual post by adding "comments: false" in its frontmatter
-	disqusShortname = "Your disqus shortname"
 
   # Switch to true to enable RSS icon link
 	rss = true
@@ -408,6 +409,15 @@ For example:
       # sortTaxonomyAlphabetical = true
 
 To revert back to ByCount sort, remove `sortTaxonomyAlphabetical` or set it to false.
+
+## <a name="disqus"></a>Disqus
+Hugo supports Disqus. Note that previously Disqus short name was `[params]/disqusShortname` but it stopped working. It's most likely because my custom variable had the same name as Hugo's internal variable for Disqus. Disqus shortname is now directly in the config file (similar to baseurl for example):
+
+``` toml
+disqusShortname = "whatever"
+```
+
+The disqus partial is at `layouts/partials/disqus.html`. By default it does not add Disqus when you are testing on localhost using the test server. This can be disabled (e.g. if you want to test Disqus locally) by commenting the `if and return` lines in the partial above.
 
 ## <a name="issues"></a>Issues/TODO
 If you discover any issues/bugs or want new features please use the Github issue tracker. Please keep in my mind that development has not been my day job for quite a while and I may be slow in fixing things (don't be surprised if I ask you about details).

--- a/layouts/partials/disqus.html
+++ b/layouts/partials/disqus.html
@@ -4,11 +4,12 @@
 (function() {
     // Don't ever inject Disqus on localhost--it creates unwanted
     // discussions from 'localhost:1313' on your Disqus account...
-    // if (window.location.hostname == "localhost")
-    //     return;
+    // Comment out these two lines to test Disqus locally
+    if (window.location.hostname == "localhost")
+        return;
 
     var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-    var disqus_shortname = '{{ .Site.Params.disqusShortname }}';
+    var disqus_shortname = '{{ .Site.DisqusShortname }}';
     dsq.src = '//' + disqus_shortname + '.disqus.com/embed.js';
     (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
 })();

--- a/layouts/partials/post_footer.html
+++ b/layouts/partials/post_footer.html
@@ -33,7 +33,7 @@
       <a class="basic-alignment right" href="{{ .Permalink }}" title="{{ .LinkTitle }}">{{ .LinkTitle }}</a>
     {{ end }}
   </p>
-  {{ if isset .Site.Params "disqusShortname" }}
+  {{ if .Site.DisqusShortname }}
     {{ if not (eq .Params.comments false) }}
       {{ partial "disqus.html" . }}
     {{ end }}

--- a/layouts/partials/post_header.html
+++ b/layouts/partials/post_header.html
@@ -3,7 +3,7 @@
 <header>
     <p class="meta">{{ .Date.Format "Jan 2, 2006" }}
         {{ if not .Site.Params.disableReadingTime }} - {{ .ReadingTime }} minute read {{ end }}
-        {{ if .Site.Params.disqusShortname }} - <a href="{{ .Permalink }}#disqus_thread">Comments</a>{{ end }}
+        {{ if .Site.DisqusShortname }} - <a href="{{ .Permalink }}#disqus_thread">Comments</a>{{ end }}
 
         {{ if isset .Params "categories" }}
         <!-- <br/> this will make the categories go to the second line and mess with the title -->

--- a/sample-config.toml
+++ b/sample-config.toml
@@ -4,6 +4,11 @@ languageCode = "en-us"
 title = "Site title"
 theme = "hugo-octopress"
 
+# Disqus shortcode
+# Disable comments for any individual post by adding "comments: false" in its frontmatter
+# Note it's not under [params] anymore
+disqusShortname = "Your disqus shortname"
+
 # Number of blog posts in each pagination page
 paginate = 6
 
@@ -91,10 +96,6 @@ post = "/blog/:year-:month-:day-:title/" # change the post URL to look like the 
   # Google analytics code - remove if you do not have/want Google Analytics - needs JavaScript
   # googleAnalytics = "UA-XXXXX-X"
 
-  # Disqus shortcode
-  # Disable comments for any individual post by adding "comments: false" in its frontmatter
-  disqusShortname = "Your disqus shortname"
-
   # Switch to true to enable RSS icon link
   rss = true
 
@@ -166,7 +167,7 @@ post = "/blog/:year-:month-:day-:title/" # change the post URL to look like the 
   URL = "/"
   weight = 2
 
-# Blackfriday is Hugo's markdown engine. Options are at: https://gohugo.io/overview/configuration/ (scroll down to "Configure Blackfriday rendering")
+# Blackfriday is Hugo's markdown engine. Options are at: https://gohugo.io/overview/configuration/#configure-blackfriday-rendering
 [blackfriday]
   hrefTargetBlank = true # open the external links in a new window
   fractions = false


### PR DESCRIPTION
This was most likely because Hugo's internal disqus shortname is the same as
my custom variable because they were both disqusShortname.
The theme now uses Hugo's internal variable.
README and sample-config have also been updated to reflect this.