### PR TITLE
Added piwik support

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,10 @@ post = "/blog/:year-:month-:day-:title/"
 	# Google analytics code - remove if you do not have/want Google Analytics - needs JavaScript
 	googleAnalytics = "UA-XXXXX-X"
 
+  # Piwik code - remove if you do not have/want Piwik tracking - needs JavaScript
+  # piwikUrl = "http://piwik.mydomain.tld
+  # piwikID = 1
+
   # Switch to true to enable RSS icon link
 	rss = true
 

--- a/README.md
+++ b/README.md
@@ -76,9 +76,10 @@ post = "/blog/:year-:month-:day-:title/"
 	# Google analytics code - remove if you do not have/want Google Analytics - needs JavaScript
 	googleAnalytics = "UA-XXXXX-X"
 
-  # Piwik code - remove if you do not have/want Piwik tracking - needs JavaScript
-  # piwikUrl = "http://piwik.mydomain.tld
-  # piwikID = 1
+  # Optional piwik tracking
+  #[params.analytics.piwik]
+  #  URL = "https://stats.example.com"
+  #  ID = "42"
 
   # Switch to true to enable RSS icon link
 	rss = true

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -5,6 +5,21 @@
 
 </footer>
 
+{{ with .Site.Params.piwikUrl }}
+<script type="text/javascript">
+  var _paq = _paq || [];
+  _paq.push(['trackPageView']);
+  _paq.push(['enableLinkTracking']);
+  (function() {
+    var u="//{{ .Site.Params.piwikUrl }}/";
+    _paq.push(['setTrackerUrl', u+'piwik.php']);
+    _paq.push(['setSiteId', '{{ .Site.Params.piwikID }}']);
+    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+    g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
+  })();
+</script>
+{{ end }}
+
 {{ with .Site.Params.googleAnalytics }}
 <script>
   var _gaq=[['_setAccount','{{ . }}'],['_trackPageview']];

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -9,6 +9,7 @@
 <script type="text/javascript">
   var _paq = _paq || [];
   /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+  _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
   _paq.push(['trackPageView']);
   _paq.push(['enableLinkTracking']);
   (function() {

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -5,20 +5,21 @@
 
 </footer>
 
-{{ with .Site.Params.piwikUrl }}
+<!-- Piwik -->
 <script type="text/javascript">
   var _paq = _paq || [];
+  /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
   _paq.push(['trackPageView']);
   _paq.push(['enableLinkTracking']);
   (function() {
-    var u="//{{ .Site.Params.piwikUrl }}/";
+    var u="//{{ .Site.Params.analytics.piwik.URL }}/";
     _paq.push(['setTrackerUrl', u+'piwik.php']);
-    _paq.push(['setSiteId', '{{ .Site.Params.piwikID }}']);
+    _paq.push(['setSiteId', {{ .Site.Params.analytics.piwik.ID }}]);
     var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
     g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
   })();
 </script>
-{{ end }}
+<!-- End Piwik Code -->
 
 {{ with .Site.Params.googleAnalytics }}
 <script>

--- a/sample-config.toml
+++ b/sample-config.toml
@@ -96,6 +96,10 @@ post = "/blog/:year-:month-:day-:title/" # change the post URL to look like the 
   # Google analytics code - remove if you do not have/want Google Analytics - needs JavaScript
   # googleAnalytics = "UA-XXXXX-X"
 
+  # Piwik code - remove if you do not have/want Piwik tracking - needs JavaScript
+  # piwikUrl = "http://piwik.mydomain.tld
+  # piwikID = 1
+
   # Switch to true to enable RSS icon link
   rss = true
 

--- a/sample-config.toml
+++ b/sample-config.toml
@@ -96,9 +96,10 @@ post = "/blog/:year-:month-:day-:title/" # change the post URL to look like the 
   # Google analytics code - remove if you do not have/want Google Analytics - needs JavaScript
   # googleAnalytics = "UA-XXXXX-X"
 
-  # Piwik code - remove if you do not have/want Piwik tracking - needs JavaScript
-  # piwikUrl = "http://piwik.mydomain.tld
-  # piwikID = 1
+  # Optional piwik tracking
+  #[params.analytics.piwik]
+  #  URL = "https://stats.example.com"
+  #  ID = "42"
 
   # Switch to true to enable RSS icon link
   rss = true


### PR DESCRIPTION
I have added support for Piwik, as i suggested in https://github.com/parsiya/Hugo-Octopress/issues/39

The piwik integration is made by two settings in the config file, `piwikUrl` and `piwikID` which are the two variables needed for Piwik integration. The first one points to a PiwikInstallation, and the second specifies the siteID in this piwik installation.

If a user does not want to enable tracking, he/she can just comment both settings out (like the already existing googleAnalytics code). 