### PR TITLE
Added isso support

### DIFF
--- a/layouts/partials/isso.html
+++ b/layouts/partials/isso.html
@@ -1,0 +1,4 @@
+<script data-isso="{{ .Site.issoURL }}/"
+        src="{{ .Site.issoURL }}/js/embed.min.js"></script>
+
+<section id="isso-thread"></section>

--- a/layouts/partials/post_footer.html
+++ b/layouts/partials/post_footer.html
@@ -38,4 +38,9 @@
       {{ partial "disqus.html" . }}
     {{ end }}
   {{ end }}
+  {{ if .Site.issoURL }}
+    {{ if not (eq .Params.comments false) }}
+      {{ partial "isso.html" . }}
+    {{ end }}
+  {{ end }}
 </footer>

--- a/sample-config.toml
+++ b/sample-config.toml
@@ -9,6 +9,11 @@ theme = "hugo-octopress"
 # Note it's not under [params] anymore
 disqusShortname = "Your disqus shortname"
 
+# Isso URL
+# Disable comments for any individual post by adding "comments: false" in its frontmatter
+# Should be mutual exclusive with disqusShortname, since it will look weird, then.
+# issoURL = "https://comments.example.tld
+
 # Number of blog posts in each pagination page
 paginate = 6
 


### PR DESCRIPTION
I have added rudimentary support for [Isso](https://posativ.org/isso/). 
Isso is a comment system, best described as "self-hosted disqus". 

One has to define `issoURL` to include an isso form into the footer of a post. It respects the `comments` param of a post, like disqus does. The only quirk: If the user defines `DisqusShortname` and `issoURL`, a post has two comment sections. 