### PR TITLE
Fix a nil pointer error in template

### DIFF
--- a/layouts/partials/classic_index.html
+++ b/layouts/partials/classic_index.html
@@ -4,26 +4,28 @@
   <div id="content">
     <div class="blog-index">
       {{ $paginator := where site.RegularPages "Type" "in" site.Params.mainSections | .Paginate }}
-      {{ range $paginator.Pages }}
-      <article>
-        <!-- {{ .Scratch.Set "isHome" true }}  -->
-        {{ partial "post_header.html" . }}
-        {{ if eq .Site.Params.truncate false }}
-          {{ .Content }}
-        {{ else if .Description }}
-          {{ .Description }}
-            <footer>
-              <a href="{{ .Permalink }}" rel="full-article">{{ with .Site.Params.continueReadingText }}{{ . | markdownify }}{{ else }}Read On &rarr;{{ end }}</a>
-            </footer>
-        {{ else }}
-          <p>{{ .Summary }}</p>
-          {{ if .Truncated }}
-            <footer>
-              <a href="{{ .Permalink }}" rel="full-article">{{ with .Site.Params.continueReadingText }}{{ . | markdownify }}{{ else }}Read On &rarr;{{ end }}</a>
-            </footer>
+      {{ if $paginator }}
+        {{ range $paginator.Pages }}
+        <article>
+          <!-- {{ .Scratch.Set "isHome" true }}  -->
+          {{ partial "post_header.html" . }}
+          {{ if eq .Site.Params.truncate false }}
+            {{ .Content }}
+          {{ else if .Description }}
+            {{ .Description }}
+              <footer>
+                <a href="{{ .Permalink }}" rel="full-article">{{ with .Site.Params.continueReadingText }}{{ . | markdownify }}{{ else }}Read On &rarr;{{ end }}</a>
+              </footer>
+          {{ else }}
+            <p>{{ .Summary }}</p>
+            {{ if .Truncated }}
+              <footer>
+                <a href="{{ .Permalink }}" rel="full-article">{{ with .Site.Params.continueReadingText }}{{ . | markdownify }}{{ else }}Read On &rarr;{{ end }}</a>
+              </footer>
+            {{ end }}
           {{ end }}
+        </article>
         {{ end }}
-      </article>
       {{ end }}
       <!-- {{ template "_internal/pagination.html" . }} default pagination -->
       {{ partial "pagination.html" . }}  <!-- use custom pagination -->


### PR DESCRIPTION
```log
failed to render pages: render of "page" failed: execute of template failed: template: myarchivetype/single.html:7:5: executing "myarchivetype/single.html" at <partial "classic_index.html" .>: error calling partial: execute of template failed: template: _internal/pagination.html:21:17: executing "_internal/pagination.html$htmltemplate_stateHTMLCmt" at <$page.Paginator.TotalPages>: error calling TotalPages: runtime error: invalid memory address or nil pointer dereference
```