### PR TITLE
add support for Mastodon link in sidebar socials

### DIFF
--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -27,6 +27,7 @@
       {{ with .Site.Params.bitbucket }}<a target="_blank" rel="noopener noreferrer" href="{{ . }}" title="{{ . }}"><i class="fa fa-bitbucket fa-3x"></i></a>{{ end }}
       {{ with .Site.Params.gitlab }}<a target="_blank" rel="noopener noreferrer" href="{{ . }}" title="{{ . }}"><i class="fa fa-gitlab fa-3x"></i></a>{{ end }}
       {{ with .Site.Params.twitter }}<a target="_blank" rel="noopener noreferrer" href="{{ . }}" title="{{ . }}"><i class="fa fa-twitter fa-3x"></i></a>{{ end }}
+      {{ with .Site.Params.mastodon }}<a target="_blank" rel="me noopener noreferrer" href="{{ . }}" title="{{ . }}"><i class="fa fa-mastodon fa-3x"></i></a>{{ end }}
       {{ if not .Site.Params.fontAwesome }}
         {{ with .Site.Params.keybase }}<a target="_blank" rel="noopener noreferrer" href="{{ . }}" title="{{ . }}"><i class="fa fa-keybase fa-3x"></i></a>{{ end }} <!-- added keybase -->
       {{ else }}

--- a/sample-config.toml
+++ b/sample-config.toml
@@ -57,6 +57,7 @@ post = "/blog/:year-:month-:day-:title/" # change the post URL to look like the 
   github = "https://github.com/parsiya/Hugo-Octopress"
   bitbucket = "https://bitbucket.org/parsiya/"
   twitter = "https://twitter.com/cryptogangsta/"
+  mastodon = ""
   keybase = ""
   stackoverflow = ""
   linkedin = ""


### PR DESCRIPTION
Closes #40 

Basically what was done in the existing upstream [mastodon-support](https://github.com/parsiya/Hugo-Octopress/commit/6e77cea1886fc955914fce18a2da06a909a78ac6) attempt, but against latest main and with [a logo from Font Awesome](https://fontawesome.com/v5/icons/mastodon?s=solid&f=brands).

Icon and link work on [my very stale site](https://www.thekidds.org). The `rel="me ..."` included in the link [works](https://hachyderm.io/@robbkidd) for [verifying the corresponding back-link in the Mastodon profile](https://docs.joinmastodon.org/user/profile/#fields).