### PR TITLE
Support Google Analytics 4 using hugo internal template

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -26,13 +26,6 @@
     {{ end }}
     <!-- End Piwik Code -->
 
-    {{ with .Site.Params.googleAnalytics }}
-      <script>
-        var _gaq=[['_setAccount','{{ . }}'],['_trackPageview']];
-        (function(d,t){var g=d.createElement(t),s=d.getElementsByTagName(t)[0];
-        g.src=('https:'==location.protocol?'//ssl':'//www')+'.google-analytics.com/ga.js';
-        s.parentNode.insertBefore(g,s)}(document,'script'));
-      </script>
-    {{ end }}
+    {{ template "_internal/google_analytics.html" . }}
   </body>
 </html>

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -51,9 +51,6 @@
   <!-- Generator version for usage tracking -->
   {{ hugo.Generator }}
 
-  <!-- Google Analytics -->
-  {{ template "_internal/google_analytics_async.html" . }}
-
   <!-- Enable Twitter card -->
   {{ with .Site.Params.twitterCardEnabled }}
     {{ partial "custom_twitter_card.html" $ }}

--- a/sample-config.toml
+++ b/sample-config.toml
@@ -87,9 +87,6 @@ post = "/blog/:year-:month-:day-:title/" # change the post URL to look like the 
   # For example, &rarr; == right arrow.
   continueReadingText = "Would you like to know more? &rarr;"
 
-  # Google analytics code - remove if you do not have/want Google Analytics - needs JavaScript
-  # googleAnalytics = "UA-XXXXX-X"
-
   # Optional piwik tracking
   # [params.analytics.piwik]
   #  URL = "https://stats.example.com"
@@ -153,6 +150,11 @@ post = "/blog/:year-:month-:day-:title/" # change the post URL to look like the 
 
   # Site's custom favicon, this is a relative path to the `/static` directory
   # favicon = "newfav.png"
+
+# Google analytics code - remove if you do not have/want Google
+# Analytics - needs JavaScript.
+# googleAnalytics = "G-MEASUREMENT_ID"
+
 
 # Menu
 # If navigationNewWindow (under [params]) is set to true then all links except root ("/") will open in a new window


### PR DESCRIPTION
Use https://gohugo.io/templates/internal/#google-analytics in footer partial. Update sample-config.toml; googleAnalytics now needs to be top level rather than under [params] for the internal template to work. This might be a concern for folks upgrading their Hugo-Octopress theme.

Fixes: #75