### PR TITLE
hugo-octopress.css: Add padding around code blocks

### DIFF
--- a/static/css/hugo-octopress.css
+++ b/static/css/hugo-octopress.css
@@ -1267,7 +1267,7 @@ pre {
     border-radius: 0.0em;
     line-height: 1.45em;
     margin-bottom: 0.8em;
-    padding: 0em 0em;
+    padding: 16px 16px;
     color: #93a1a1;
     font-size: 80%;  /* change the code font size */
 


### PR DESCRIPTION
hugo-octopress.css: Add padding of 16 px around code blocks. Fixes #79.